### PR TITLE
Fix broken navigation

### DIFF
--- a/src/components/atoms/navigators/Header.jsx
+++ b/src/components/atoms/navigators/Header.jsx
@@ -14,10 +14,10 @@ export default function Header() {
           <NavLink eventKey="1" as={Link} to="/">
             Home
           </NavLink>
-          <NavLink eventKey="2" as={Link} to="/Tasbeeh">
+          <NavLink eventKey="2" as={Link} to="/tasbeeh">
             Tasbeeh
           </NavLink>
-          <NavLink eventKey="3" as={Link} to="/Calendar">
+          <NavLink eventKey="3" as={Link} to="/calendar">
             Calendar
           </NavLink>
         </Nav>

--- a/src/components/atoms/navigators/Navigation.jsx
+++ b/src/components/atoms/navigators/Navigation.jsx
@@ -17,11 +17,11 @@ const router = createBrowserRouter([
     element: <Home />,
     children: [
       {
-        path: "Tasbeeh",
+        path: "tasbeeh",
         element: <Tasbeeh />,
       },
       {
-        path: "Calendar",
+        path: "calendar",
         element: <Calendar />,
       },
     ],

--- a/src/components/atoms/navigators/Navigation.jsx
+++ b/src/components/atoms/navigators/Navigation.jsx
@@ -9,15 +9,11 @@ import "@/styles/index.css";
 
 const router = createBrowserRouter([
   {
-    path: "/",
-    element: <Home />,
-  },
-  {
     path: "/login",
     element: <Login />
   },
   {
-    path: "/home",
+    path: "/",
     element: <Home />,
     children: [
       {

--- a/src/components/screens/login/Login.jsx
+++ b/src/components/screens/login/Login.jsx
@@ -12,7 +12,7 @@ export default function Login() {
   const [invalid, setInvalid] = useState(false);
 
   if (token) {
-    return <Navigate to="/home" replace={true} state={{ memberData: memberData }} />;
+    return <Navigate to="/" replace={true} state={{ memberData: memberData }} />;
   }
 
   const updateITSValid = async () => {


### PR DESCRIPTION
# Problem

When we navigate to any header it leads us to a 404 error because the path navigated us to `/Tasbeeh`. However the route was set up to go to `/home/Tasbeeh`.

# Solution
- Eliminate the redundant `/home` route.
- Update header to route to correct pages
- Rename routes to be consistent